### PR TITLE
2 small patches 

### DIFF
--- a/triton/driver_triton.go
+++ b/triton/driver_triton.go
@@ -81,6 +81,10 @@ func (d *driverTriton) GetMachine(machineId string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if machine.PrimaryIP == "" {
+		// if we don't have a primary ip return first ip address from the ip's list
+		return machine.IPs[0], nil
+	}
 
 	return machine.PrimaryIP, nil
 }


### PR DESCRIPTION
1. in driver_triton.go GetMachine return only PrimaryIP, which it must be working for most of the cases but not for my private triton installation where primary IP is always empty, therefore I've created a patch that returns first ip address from IPs array if the PrimaryIp is empty
2. treat triton_key_material as file path and read it's content into ssh key if file exist, if the var contain the pem key the behavior is unchanged.
